### PR TITLE
Canonical repr

### DIFF
--- a/fraction/Fraction.py
+++ b/fraction/Fraction.py
@@ -2,7 +2,9 @@ class Fraction:
     def __init__(self, numerator=0, denominator=1):
         self.numerator = int(numerator)
         self.denominator = int(denominator)
-
+        self.is_normal = False
+    
+    
     def _gcd(self, num1, num2):
         if num2 == 0:
             return num1
@@ -69,8 +71,17 @@ class Fraction:
         denom_lcm = (a_d * b_d) / self._gcd(a_d, b_d)
         return True if a_n * (denom_lcm / a_d) != b_n * (denom_lcm / b_d) else False
 
+    def normalize(self):
+        if not self.is_normal:
+            g = self._gcd(self.numerator, self.denominator)
+            self.numerator = self.numerator // g
+            self.denominator = self.denominator // g
+            self.is_normal = True
+
     def __str__(self):
+        self.normalize()
         return '{}/{}'.format(self.numerator, self.denominator)
 
     def __repr__(self):
+        self.normalize()
         return 'Fraction: {}/{}'.format(self.numerator, self.denominator)

--- a/fraction/Fraction.py
+++ b/fraction/Fraction.py
@@ -71,7 +71,7 @@ class Fraction:
         denom_lcm = (a_d * b_d) / self._gcd(a_d, b_d)
         return True if a_n * (denom_lcm / a_d) != b_n * (denom_lcm / b_d) else False
 
-    def normalize(self):
+    def _normalize(self):
         if not self.is_normal:
             g = self._gcd(self.numerator, self.denominator)
             self.numerator = self.numerator // g
@@ -79,9 +79,9 @@ class Fraction:
             self.is_normal = True
 
     def __str__(self):
-        self.normalize()
+        self._normalize()
         return '{}/{}'.format(self.numerator, self.denominator)
 
     def __repr__(self):
-        self.normalize()
+        self._normalize()
         return 'Fraction: {}/{}'.format(self.numerator, self.denominator)

--- a/fraction/Fraction.py
+++ b/fraction/Fraction.py
@@ -68,9 +68,9 @@ class Fraction:
         a_n, a_d, b_n, b_d = self.numerator, self.denominator, other_fraction.numerator, other_fraction.denominator
         denom_lcm = (a_d * b_d) / self._gcd(a_d, b_d)
         return True if a_n * (denom_lcm / a_d) != b_n * (denom_lcm / b_d) else False
-    
+
     def __str__(self):
-    	return '{}/{}'.format(self.numerator, self.denominator)
+        return '{}/{}'.format(self.numerator, self.denominator)
 
     def __repr__(self):
         return 'Fraction: {}/{}'.format(self.numerator, self.denominator)


### PR DESCRIPTION
Hi!
This is a fix for issue #4. I hope it looks good. I normalize the representation at the time of converting to string, so that we don't do this if it's unnecessary. Then I store a flag self.is_normal so that we don't perform this calculation more than once.